### PR TITLE
bug:UIManager DeActive()함수에 book UI 제어도 추가 #251

### DIFF
--- a/Assets/RefactoringManagerSystem/UIManager.cs
+++ b/Assets/RefactoringManagerSystem/UIManager.cs
@@ -134,6 +134,8 @@ namespace Ciart.Pagomoa.Systems
             minimapUI.gameObject.SetActive(false);
             stateUI.gameObject.SetActive(false);
             quickUI.gameObject.SetActive(false);
+            
+            bookUI.DeActiveBook();
         }
 
         public void ActiveUI()


### PR DESCRIPTION
## 작업내용
컷씬 시작시 bookUI가 활성화 되어있을 경우 그대로 컷씨까지 보여서 컷신 시작시 bookUI Off 토글되게 변경

## 관련 이슈
- #251 

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 하기 전 main 브랜치를 pull했습니다.
- [x] title, labels, assignees을 채우고 이슈를 연결했습니다.
