### PR TITLE
채굴 플레이 경험 개선

### DIFF
--- a/Assets/RefactoringManagerSystem/GameSystem.cs
+++ b/Assets/RefactoringManagerSystem/GameSystem.cs
@@ -65,6 +65,7 @@ namespace Ciart.Pagomoa.Systems
         public void MoveToNextDay()
         {
             Time.SkipToNextDay();
+            player!.Health = player.MaxHealth;
             SaveSystem.Instance.Save();
         }
 

--- a/Assets/RefactoringManagerSystem/TimeManager.cs
+++ b/Assets/RefactoringManagerSystem/TimeManager.cs
@@ -14,7 +14,6 @@ namespace Ciart.Pagomoa.Systems.Time
     {
         ~TimeManager()
         {
-            EventManager.RemoveListener<PlayerSpawnedEvent>(OnPlayerSpawned);
             Task.FromCanceled(CancellationToken.None);
         }
 
@@ -55,29 +54,45 @@ namespace Ciart.Pagomoa.Systems.Time
 
         public bool canSleep = false;
 
-        public bool isTimeStop = false;
+
+        private bool _isPause = false;
+
+        public bool IsPause
+        {
+            get => _isPause;
+            private set
+            {
+                if (value)
+                {
+                    UnityEngine.Time.timeScale = 0;
+                    _isPause = true;
+                    paused?.Invoke();
+                }
+                else
+                {
+                    UnityEngine.Time.timeScale = 1;
+                    _isPause = false;
+                    resumed?.Invoke();
+                }
+            }
+        }
 
         private float _nextUpdateTime = 0f;
 
         private PlayerInput _playerInput;
 
+        private int _wantPauseCount = 0;
+
         public event Action<int> tickUpdated;
 
-        public override void Start()
-        {
-            EventManager.AddListener<PlayerSpawnedEvent>(OnPlayerSpawned);
-        }
+        public event Action paused;
 
-        private void OnPlayerSpawned(PlayerSpawnedEvent e)
-        {
-            var player = e.player;
-            _playerInput = player.GetComponent<PlayerInput>();
-        }
+        public event Action resumed;
 
         public override void Update()
         {
             if (DataBase.data.GetCutSceneController().CutSceneIsPlayed() == true) return;
-            if (isTimeStop == true) return;
+            if (IsPause == true) return;
             if (tick >= MaxTick) return;
 
             if (_nextUpdateTime <= 0)
@@ -89,7 +104,7 @@ namespace Ciart.Pagomoa.Systems.Time
 
                 if (tick >= MaxTick)
                 {
-                    Game.Instance.player.Die();
+                    Game.Instance.player!.Die();
                     return;
                 }
             }
@@ -125,26 +140,35 @@ namespace Ciart.Pagomoa.Systems.Time
 
         public void PauseTime()
         {
-            UnityEngine.Time.timeScale = 0;
-            isTimeStop = true;
-            if (_playerInput) _playerInput.Actable = false;
+            if (_wantPauseCount == 0)
+            {
+                IsPause = true;
+            }
+
+            _wantPauseCount++;
         }
 
         public void ResumeTime()
         {
-            UnityEngine.Time.timeScale = 1;
-            isTimeStop = false;
-            if (_playerInput) _playerInput.Actable = true;
+            if (_wantPauseCount > 0)
+            {
+                _wantPauseCount--;
+
+                if (_wantPauseCount == 0)
+                {
+                    IsPause = false;
+                }
+            }
         }
-        
+
         public void RegisterTickEvent(Action<int> action)
         {
             if (!tickUpdated.GetInvocationList().Contains(action))
             {
-                tickUpdated += action;   
+                tickUpdated += action;
             }
         }
-        
+
         public void UnregisterTickEvent(Action<int> action)
         {
             if (tickUpdated.GetInvocationList().Contains(action))

--- a/Assets/Scripts/Entities/Players/PlayerInput.cs
+++ b/Assets/Scripts/Entities/Players/PlayerInput.cs
@@ -1,4 +1,5 @@
 ﻿using Ciart.Pagomoa.Events;
+using Ciart.Pagomoa.Systems;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -35,6 +36,8 @@ namespace Ciart.Pagomoa.Entities.Players
         private void Update()
         {
             if (!Actable) return;
+
+            if (Game.Instance.Time.IsPause) return;
 
             Move = Actions.Move.ReadValue<Vector2>();
             Look = Actions.Look.ReadValue<Vector2>();

--- a/Assets/Scripts/PlatformController.cs
+++ b/Assets/Scripts/PlatformController.cs
@@ -53,7 +53,7 @@ namespace Ciart.Pagomoa
 
         private bool CheckPassingPlayer()
         {
-            if (_player == null || _playerInput == null)
+            if (_player == null || _playerInput == null || Game.Instance.Time.IsPause)
             {
                 return false;
             }
@@ -81,7 +81,7 @@ namespace Ciart.Pagomoa
             }
             else
             {
-                _enableTime -= Time.deltaTime;
+                _enableTime -= Time.unscaledDeltaTime;
             }
 
             if (_enableTime >= 0f)

--- a/Assets/Scripts/PlatformController.cs
+++ b/Assets/Scripts/PlatformController.cs
@@ -11,6 +11,8 @@ namespace Ciart.Pagomoa
     {
         private CompositeCollider2D _collider;
 
+        private PlayerController _player;
+
         private PlayerInput _playerInput;
 
         private BoxCollider2D _playerCollider;
@@ -19,6 +21,7 @@ namespace Ciart.Pagomoa
         
         private void SetPlayerComponent(PlayerController player)
         {
+            _player = player;
             _playerInput = player.GetComponent<PlayerInput>();
             _playerCollider = player.GetComponent<BoxCollider2D>();
         }
@@ -37,9 +40,9 @@ namespace Ciart.Pagomoa
         {
             EventManager.AddListener<PlayerSpawnedEvent>(OnPlayerSpawnedEvent);
 
-            if (Game.instance.player != null)
+            if (Game.Instance.player != null)
             {
-                SetPlayerComponent(Game.instance.player);
+                SetPlayerComponent(Game.Instance.player);
             }
         }
 
@@ -48,9 +51,31 @@ namespace Ciart.Pagomoa
             EventManager.RemoveListener<PlayerSpawnedEvent>(OnPlayerSpawnedEvent);
         }
 
+        private bool CheckPassingPlayer()
+        {
+            if (_player == null || _playerInput == null)
+            {
+                return false;
+            }
+
+            if (DirectionUtility.ToDirection(_playerInput.Move) == Direction.Down)
+            {
+                return true;
+            }
+
+            var drill = _player.drill;
+
+            if (drill.isDig && drill.isGroundHit && drill.direction == Direction.Down)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private void Update()
         {
-            if (_playerInput && DirectionUtility.ToDirection(_playerInput.Move) == Direction.Down)
+            if (_playerInput && CheckPassingPlayer())
             {
                 _enableTime = 0.5f;
             }

--- a/Assets/Scripts/PlatformController.cs
+++ b/Assets/Scripts/PlatformController.cs
@@ -17,7 +17,7 @@ namespace Ciart.Pagomoa
 
         private BoxCollider2D _playerCollider;
 
-        private float _enableTime = 0f;
+        private float _platformResetTimer = 0f;
         
         private void SetPlayerComponent(PlayerController player)
         {
@@ -77,14 +77,14 @@ namespace Ciart.Pagomoa
         {
             if (_playerInput && CheckPassingPlayer())
             {
-                _enableTime = 0.5f;
+                _platformResetTimer = 0.5f;
             }
             else
             {
-                _enableTime -= Time.unscaledDeltaTime;
+                _platformResetTimer -= Time.unscaledDeltaTime;
             }
 
-            if (_enableTime >= 0f)
+            if (_platformResetTimer >= 0f)
             {
                 Physics2D.IgnoreCollision(_playerCollider, _collider);
             }

--- a/Assets/Scripts/UI/DaySummaryUI.cs
+++ b/Assets/Scripts/UI/DaySummaryUI.cs
@@ -14,5 +14,12 @@ public class DaySummaryUI : MonoBehaviour {
     {
         var date = Game.Instance.Time.date;
         dateText.text = $"{date}일차 종료";
+
+        Game.Instance.Time.PauseTime();
+    }
+
+    private void OnDisable()
+    {
+        Game.Instance.Time.ResumeTime();
     }
 }


### PR DESCRIPTION
## 작업내용
- 플랫폼에 겹친 바닥 타일 채굴 시 플랫폼을 무시하도록 변경
- 플레이어 리스폰 시 낙하 방지
- TimeManager 일시정지에 카운터 적용

## 관련 이슈
#257 #258

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 하기 전 main 브랜치를 pull했습니다.
- [x] title, labels, assignees을 채우고 이슈를 연결했습니다.
