### PR TITLE
fix / 파티클 스폰 위치 수정

### DIFF
--- a/Assets/Scripts/Entities/EntityController.cs
+++ b/Assets/Scripts/Entities/EntityController.cs
@@ -198,7 +198,7 @@ namespace Ciart.Pagomoa.Entities
         {
             if(isDead) return;
 
-            Game.Instance.Particle.Make(0, gameObject, Vector2.zero, 0.5f);
+            Game.Instance.Particle.Make(0, gameObject, transform.position + Vector3.up * 0.5f, 0.5f);
 
             _rigidbody.AddForce(force * direction.normalized, ForceMode2D.Impulse);
         }


### PR DESCRIPTION
## 작업내용
버그수정

  1. 파티클 스폰 위치가 0으로 되어있던 것을 수정하였습니다.

## 관련 이슈
- #275 

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 하기 전 main 브랜치를 pull했습니다.
- [x] title, labels, assignees을 채우고 이슈를 연결했습니다.
