### PR TITLE
Bug/monster sleep wakeup

### DIFF
--- a/Assets/RefactoringManagerSystem/EntityManager.cs
+++ b/Assets/RefactoringManagerSystem/EntityManager.cs
@@ -115,7 +115,7 @@ namespace Ciart.Pagomoa.Entities
 
         private void SleepAndWakeUpMonsterEntity(int tick)
         {
-            if (tick is not (TimeManager.Morning
+            if (tick is not ((TimeManager.Morning)
                 or TimeManager.MaxTick - 6000)) return;
 
             foreach (var entityList in _entities)
@@ -123,10 +123,10 @@ namespace Ciart.Pagomoa.Entities
                 foreach (var monster in entityList.Value)
                 {
                     var controller = monster.GetComponent<MonsterController>();
-                    if (!controller || monster.CompareTag("Monster")) continue;
-                    controller.StateChanged(tick != TimeManager.Morning
-                        ? Monster.MonsterState.Sleep
-                        : Monster.MonsterState.Active);
+                    if (!controller || !monster.CompareTag("Monster")) continue;
+                    controller.StateChanged(tick == TimeManager.Morning
+                        ? Monster.MonsterState.Active
+                        : Monster.MonsterState.Sleep);
                 }
             }
         }

--- a/Assets/RefactoringManagerSystem/TimeManager.cs
+++ b/Assets/RefactoringManagerSystem/TimeManager.cs
@@ -103,12 +103,17 @@ namespace Ciart.Pagomoa.Systems.Time
             if (IsPause == true) return;
             if (tick >= MaxTick) return;
 
+            if (Input.GetKeyDown(KeyCode.Alpha0))
+                tick += 1600;
+            if (Input.GetKeyDown(KeyCode.Alpha9))
+                tick += 30;
             if (_nextUpdateTime <= 0)
             {
                 // 튜토리얼 진행 중에는 시간이 흐르지 않습니다.
                 if (!IsTutorialDay)
                 {
                     tick += 1;
+                    Debug.Log(tick);
                 }
 
                 //To do : tick have to change into 1, But should be do before Release. Not now.
@@ -129,6 +134,7 @@ namespace Ciart.Pagomoa.Systems.Time
         {
             AddDay(1);
             tick = Morning;
+            tickUpdated.Invoke(tick);
         }
 
         public void AddTime(int hourToAdd, int minuteToAdd)

--- a/Assets/Timelines/ShopkeeperTrigger.cs
+++ b/Assets/Timelines/ShopkeeperTrigger.cs
@@ -31,13 +31,14 @@ namespace Ciart.Pagomoa.Timelines
         
         public override void OnCutSceneTrigger(int tick)
         {
-            if (!_trigger && Game.Instance.Time.date == 0)
+            if (!_trigger && Game.Instance.Time.IsTutorialDay)
             {
                 _tutorialCounter = 0;
                 _trigger = Instantiate(this, instantiatedPos, Quaternion.identity);
                 DontDestroyOnLoad(_trigger);
                 EventManager.AddListener<QuestUpdated>(CheckTutorialQuestEnd);
             }
+            
         }
         public override void OffCutSceneTrigger()
         {
@@ -51,7 +52,7 @@ namespace Ciart.Pagomoa.Timelines
         private void CheckTutorialQuestEnd(QuestUpdated e)
         {
             if (e.quest.state != QuestState.Finish) return;
-            var contains = e.quest.id.Contains("tutorial");
+            var contains = e.quest.id.Contains("tutorial_2") || e.quest.id.Contains("tutorial_1");
             if (contains) _tutorialCounter++;
             if (_tutorialCounter == 2)
             {
@@ -67,7 +68,5 @@ namespace Ciart.Pagomoa.Timelines
             
             Destroy(gameObject);
         }
-        
-        
     }
 }


### PR DESCRIPTION
## 작업내용
몬스터가 틱 이벤트에 따른 잠자기와 일어나기를 수행하도록 조정

## PR 체크리스트
- [ ] 로컬 빌드가 정상적으로 실행되었습니다.
- [ ] PR 하기 전 main 브랜치를 pull했습니다.
- [ ] title, labels, assignees을 채우고 이슈를 연결했습니다.
